### PR TITLE
Delivery Location popup iteration

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -7,6 +7,11 @@ function bundle_upsells()
 ?>
 	<script>
 		jQuery(document).ready(function() {
+			/*** DELETE ME ****/
+			jQuery(document).ready(function () {
+				jQuery(".close_popup_btn").click(function() { jQuery(".my-overlay").hide() })
+			})
+			/*** END DELETE ME ***/
 			var pattern = RegExp('/product/')
 
 			if (pattern.test(window.location.href)) {
@@ -76,6 +81,7 @@ function disable_checkout_fields($fields)
 
 	$fields['shipping']['shipping_city']['custom_attributes']       = array('readonly' => true);
 	$fields['shipping']['shipping_postcode']['custom_attributes']   = array('readonly' => true);
+	
 
 	return $fields;
 }
@@ -94,6 +100,9 @@ function storing_checkout_data_in_session()
 {
 ?>
 	<script>
+    
+    // Looping through the state values on checkout page and getting data from session 
+
 		const statesMap = {
 			ACT: "Australian Capital Territory",
 			NSW: "New South Wales",
@@ -119,10 +128,7 @@ function storing_checkout_data_in_session()
 
 					document.getElementById("shipping_state")
 						.value = data.state
-					// 				   el.setAttribute("value", statesMap[data.state])
-
-
-					//   el.innerText = statesMap[data.state]
+				
 				}
 
 			}
@@ -143,9 +149,7 @@ function session_delivery_location_state()
 			if (user_city_new == null || user_city_new == undefined || user_city_new === '') {
 
 
-				if (current_page_path.match(/product-category/gi) || current_page_path.match(/product-tag/gi) || current_page_path.match(/flower-delivery/gi) ||
-					current_page_path.match(/nsw/gi) || current_page_path.match(/qld/gi) || current_page_path.match(/vic/gi) || current_page_path.match(/sa/gi) ||
-					current_page_path.match(/wa/gi) || current_page_path.match(/tas/gi)) {
+				if (current_page_path.match(/product-category/gi) || current_page_path.match(/product-tag/gi)) {
 
 
 
@@ -158,6 +162,19 @@ function session_delivery_location_state()
 			} else {
 
 				jQuery('.my_new_popup').hide();
+				
+				jQuery("a").each(function (item, index) {
+					var href = jQuery(this).attr("href");
+					if (!href) return
+					if (href.match(/filter_city/gi)) return
+					if (href.match(/product-tag/gi) || href.match(/product-category/gi)) {
+						if (href.match(/\?/gi)) {
+							jQuery(this).attr("href", href + "filter_city=" + JSON.parse(sessionStorage.getItem('state-info')).attr_city);
+						} else {
+							jQuery(this).attr("href", href + "?filter_city=" + JSON.parse(sessionStorage.getItem('state-info')).attr_city);	
+						}
+					}
+				});
 			}
 
 			if (user_city_new == null || user_city_new == undefined || user_city_new === '') {
@@ -173,6 +190,8 @@ function session_delivery_location_state()
 				$(".my_new_popup").hide();
 			});
 
+			
+	// Auto-complete form using fetch API		
 			function formatResult(result) {
 				return result.suburb + ", " + result.state + ", " + result.postcode
 			}
@@ -208,12 +227,22 @@ function session_delivery_location_state()
 						})
 						.then(function(result) {
 							selectedState = result
-							$("#location").val(formatResult(result));
+						$("#location").val(formatResult(result));
+							var formatted_results_var = $("#location").val(formatResult(result));
+						
+						if (formatted_results_var !=""){
 							$("#confirm-location").prop("disabled", false);
+
+							} 
 						});
 				}
 
 			});
+
+	// Confirm Location button will trigger this code if session data is empty
+
+			if (user_city_new == null || user_city_new == undefined || user_city_new === '') {
+
 			$("#confirm-location").click(() => {
 				var state_info = JSON.stringify(selectedState)
 
@@ -235,11 +264,84 @@ function session_delivery_location_state()
 
 			})
 
+			}
+
+// Confirm Location button will trigger this code if session data is not empty
+
+if (user_city_new != null || user_city_new != undefined || user_city_new != '') {
+	
+	if (user_city_new !=null){
+		var input_value_from_session = document.getElementById("location")
+		.value =  toJSON_new.suburb + ", " + toJSON_new.state + ", " + toJSON_new.postcode
+		var pre_session_data = 	toJSON_new.suburb + ", " + toJSON_new.state + ", " + toJSON_new.postcode
+var new_results_from_session = pre_session_data.localeCompare(input_value_from_session)
+		}
+	
+
+		if(input_value_from_session){
+					$("#confirm-location").prop("disabled", false);
+				}
 
 
+	$("#confirm-location").click(() => {
+		
+				var state_info = JSON.stringify(selectedState)
+if  (document.getElementById("location")
+		.value != input_value_from_session) {
+				sessionStorage.setItem("state-info", `${state_info}`)
+						 
+					 }
+				var new_current_page_path = window.location.pathname;
+	
+				 if (new_current_page_path.match(/product-category/gi) || new_current_page_path.match(/product-tag/gi)) {
+					 
+					 if (new_results_from_session == 0 && $("#location").val() == input_value_from_session){
+
+					$(".my_new_popup").hide();
+
+	} else {
+					 
+					 
+					window.location.href = location.origin + location.pathname +
+						'?filter_city=' + selectedState.attr_city
+	}
+					 
+				} else if (new_current_page_path.match(/checkout/gi)) {
+					
+					 if (new_results_from_session == 0 && $("#location").val() == input_value_from_session){
+
+					$(".my_new_popup").hide();
+
+	} else{
+					
+					
+					
+					window.location.href = location.origin + location.pathname
+	}
+				} else {
+					
+					 if (new_results_from_session == 0 && $("#location").val() == input_value_from_session){
+
+					$(".my_new_popup").hide();
+
+	} else{
+					
+					window.location.href = location.origin + location.pathname + selectedState.attr_city
+
+	}
+				}
+
+
+			})
+	
+			
+}
+// Refreshing current page if change of path is detected
 
 			if (user_city_new != null || user_city_new != undefined || user_city_new != '') {
-
+				
+				
+					
 				if (current_page_path.match(/product-category/gi) || current_page_path.match(/product-tag/gi)) {
 					if (window.location.href.includes("filter_city")) {} else {
 						const get_user_suburb = sessionStorage.getItem('state-info')
@@ -262,26 +364,34 @@ function session_delivery_location_state()
 					}
 				}
 			}
+
+
+      //Triggerring location popup on specific element ID's
+
 			$("#location_btnne").click(() => {
-				jQuery('.my_new_popup').show();
+				jQuery('.my_new_popup,.my-overlay').show();
 
 			})
 			$("#shipping_city").click(() => {
-				jQuery('.my_new_popup').show();
+				jQuery('.my_new_popup,.my-overlay').show();
 
 			})
-			$("#shipping_state").click(() => {
-				jQuery('.my_new_popup').show();
+			$("#shipping_state_field").click(() => {
+				jQuery('.my_new_popup,.my-overlay').show();
 
 			})
 			$("#select2-shipping_state-container").click(() => {
-				jQuery('.my_new_popup').show();
+				jQuery('.my_new_popup,.my-overlay').show();
 
 			})
 			$("#shipping_postcode").click(() => {
-				jQuery('.my_new_popup').show();
+				jQuery('.my_new_popup,.my-overlay').show();
 
 			})
+
+// 			$("#shipping_state").prop("disabled", true);
+// 			$('#shipping_state').css({ opacity: 0.9});
+
 			// 	$("#location").autocomplete({
 			//         select: function(event, ui) {
 			//             $("#confirm-location").val(ui.item.term);
@@ -292,29 +402,14 @@ function session_delivery_location_state()
 			//     }).data("uiItem",$(result).val());
 
 
+// Disable Confirm button if the location input is empty
 
-			// 	 $('#location').keyup(function(){
-			//     if($(this).val() != ""){
-			//         $('#confirm-location').attr('disabled', false); 
-
-			//         $('#confirm-location').css({
-			//             'background-color':'#f4b9b8 !important', 
-			//             'color' : '#000000 !important',
-			//             'cursor': 'pointer'
-			//         }
-			//         ) ;    
-			//     }    
-			//     else{
-			//         $('#confirm-location').css({
-			//             'background-color':'#151515 ', 
-			//             'color' : '#fff ',
-
-
-			//         }
-			//         ) ;    
-
-			//     }
-			// })
+				 $('#location').keyup(function(){
+			    if($(this).val() == ""){
+			        $('#confirm-location').attr('disabled', true); 
+      
+			    }    
+			    });
 
 		});
 	</script>
@@ -532,3 +627,4 @@ function replacing_add_to_cart_button($button, $product)
 
 	return $button;
 }
+

--- a/style.css
+++ b/style.css
@@ -11,20 +11,113 @@
 	License URI: -
 */
 
-.shipping_city_field {
-  pointer-events: none;
+/*** Style My Overlay ***/
+.my-overlay {
+    display: flex;
+    position: fixed;
+    align-items: center;
+    justify-content: center;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    height: 100vh;
+    z-index: 999991;
+    overflow: hidden auto;
+    padding: 0 15px;
+}
+
+.my-overlay-mask {
+    background-color: rgba(255, 255, 255, 0.85);
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+}
+
+.my-overlay-container {
+    max-width: 90%;
+    background-color: rgb(13, 13, 13);
+    display: flex;
+    align-items: center;
+    z-index: 999999;
+    padding: 40px 10vw;
+    align-items: center;
+    justify-content: center;
+}
+.my-overlay-content {
+    max-width: 100%;
+}
+.my-overlay-container li {
+    list-style-type: none;
+    border: 1px solid #ffffff;
+    min-width: 30vh;
+    transition: background-color 0.1s ease;
+}
+
+.my-overlay-container li:hover {
+    list-style-type: none;
+    background: #ffffff;
+}
+
+.my-overlay-container li:hover a {
+    color: rgb(13, 13, 13);
+}
+
+.my-overlay h2, 
+.my-overlay-container a {
+    color: #fff
+}
+
+.my-overlay h2 {
+    font-size: 5rem;
+    font-weight: 700;
+    text-align: center;
+    line-height: 1;
+    text-transform: uppercase;
+    padding: 10px 0;
+    letter-spacing: 0.5rem;
+}
+
+.my-overlay a {
+    font-size: 1.2rem;
+    width: 100%;
+    height: 100%;
+    display: inline-block;
+    text-align: center;
+    padding: 7px 0;
+}
+.close_popup_btn:after{
+    content: "×";
+    color: #343434;
+    font-size: 35px;
+	opacity: 0.9;
+	cursor:pointer;
+}
+
+.close_popup_btn{
+	height:430px;
+}
+@media only screen and (max-width: 768px) {
+  /* For mobile phones: */
+  h2 {
+    font-size: 2rem !important;
+  }
+}
+
+
+
+/**** Written by Jahanzaib ***/
+#shipping_state_field{
+    pointer-events:none;
+    
 }
 
 #pop_up_btn_triger {
   line-height: 1.4;
 }
 
-.select2.select2-container--default {
-  pointer-events: none;
-}
-.select2.select2-container.select2-container--default.select2-container--above.select2-container--focus {
-  pointer-events: none;
-}
 
 @media only screen and (max-width: 600px) {
   #popup_head_ing {
@@ -34,6 +127,7 @@
 
   .close_popup_btn {
     margin-left: -30px;
+    margin-bottom:30px;
   }
 }
 
@@ -143,6 +237,28 @@
   margin-top: 10px !important;
 }
 
+#confirm-location-new {
+  text-decoration: none !important;
+  border: 2px solid white !important;
+  width: 100% !important;
+  color: white !important;
+  margin-top: 10px !important;
+}
+
 #confirm-location:disabled {
   opacity: 0.5;
+}
+
+#confirm-location-new:disabled {
+  opacity: 0.5;
+}
+
+.row {
+	margin-left: 0;
+	margin-right: 0;
+}
+
+.page-padding.shop-header-style1 {
+    margin-left: 15px !important;
+    margin-right: 15px !important;
 }


### PR DESCRIPTION
(1) When popup fires and we have location in state, we should populate input with data from state

(2) When user clicks Continue, we should difference submitted state and stored state; if there is no change the popup should simply be closed, and page would not be refreshed.

fixed delivery location popup issue on the checkout page.